### PR TITLE
Fix build on Windows; support LLVM toolkit

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,7 @@ class ICUConan(ICUBase):
     def build_requirements(self):
         super(ICUConan, self).build_requirements()
         if self.cross_building:
-            self.build_requires("icu_installer/%s@bincrafters/stable" % self.version)
+            self.build_requires("icu_installer/%s@datalogics/stable" % self.version)
 
     def package_id(self):
         del self.info.options.with_unit_tests  # ICU unit testing shouldn't affect the package's ID

--- a/icu_base.py
+++ b/icu_base.py
@@ -42,7 +42,7 @@ class ICUBase(ConanFile):
     def build_requirements(self):
         if self._the_os == "Windows":
             #self.build_requires("cygwin_installer/2.9.0@bincrafters/stable")
-            self.build_requires("msys2_installer/latest@bincrafters/stable")
+            self.build_requires("msys2/20190524@datalogics/stable")
             if self.settings.compiler == "gcc" and tools.os_info.is_windows:
                 self.build_requires("mingw_installer/1.0@conan/stable")
 
@@ -89,7 +89,7 @@ class ICUBase(ConanFile):
             tools.replace_in_file(run_configure_icu_file, "-MDd", flags)
             tools.replace_in_file(run_configure_icu_file, "-MD", flags)
 
-        self._replace_pythonpath() # ICU 64.1
+        # self._replace_pythonpath() # ICU 64.1
         self._workaround_icu_20545()
 
         self._env_build = AutoToolsBuildEnvironment(self)

--- a/icu_base.py
+++ b/icu_base.py
@@ -89,6 +89,11 @@ class ICUBase(ConanFile):
             tools.replace_in_file(run_configure_icu_file, "-MDd", flags)
             tools.replace_in_file(run_configure_icu_file, "-MD", flags)
 
+            toolset = self.settings.get_safe("compiler.toolset") or ""
+            if "LLVM" in toolset.upper():
+                tools.replace_in_file(run_configure_icu_file, "CC=cl", "CC=clang-cl")
+                tools.replace_in_file(run_configure_icu_file, "CXX=cl", "CXX=clang-cl")
+
         # self._replace_pythonpath() # ICU 64.1
         self._workaround_icu_20545()
 


### PR DESCRIPTION
- Bring in changes from Bincrafters.

- Use a more modern version of msys2 (packaged at Datalogics for now). This resolves the problem with `sh.exe` crashing, which can manifest as "the C compiler can't create executables".

- Edit the `runConfigureICU` file to use `clang-cl` if `"LLVM"` is found in the `compiler.toolset`. This seemed less invasive than changing things to call `configure` directly, and when I was experimenting with using `cygwin_installer`, it also worked better.

Once this is merged, I'll push up the recipe to our Artifactory and we can test builds.