### PR TITLE
Fix building on Solaris with data_packaging=library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,7 @@ class ICUConan(ICUBase):
                        "with_extras": True,
                        "with_unit_tests": False,
                        "silent": True}
+    generators = 'txt', 'virtualenv'
 
     def build_requirements(self):
         super(ICUConan, self).build_requirements()

--- a/icu_base.py
+++ b/icu_base.py
@@ -117,9 +117,9 @@ class ICUBase(ConanFile):
 
                     self.run(self._build_config_cmd, win_bash=tools.os_info.is_windows)
                     if self.options.get_safe("silent"):
-                        silent = '--silent' if self.options.silent else 'VERBOSE=1'
-                    else:
                         silent = '--silent'
+                    else:
+                        silent = 'VERBOSE=1'
                     command = "make {silent} -j {cpu_count}".format(silent=silent,
                                                                     cpu_count=tools.cpu_count())
                     self.run(command, win_bash=tools.os_info.is_windows)

--- a/icu_base.py
+++ b/icu_base.py
@@ -109,6 +109,10 @@ class ICUBase(ConanFile):
         build_dir = os.path.join(self.build_folder, self._source_subfolder, 'build')
         os.mkdir(build_dir)
 
+        make_args = list()
+        if self.settings.os == 'SunOS' and self.settings.arch in ['x86_64', 'sparcv9']:
+            make_args.append('LDLIBRARYPATH_ENVVAR=LD_LIBRARY_PATH_64')
+
         with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
             with tools.environment_append(self._env_build.vars):
                 with tools.chdir(build_dir):
@@ -117,16 +121,17 @@ class ICUBase(ConanFile):
 
                     self.run(self._build_config_cmd, win_bash=tools.os_info.is_windows)
                     if self.options.get_safe("silent"):
-                        silent = '--silent'
+                        make_args.insert(0, '--silent')
                     else:
-                        silent = 'VERBOSE=1'
-                    command = "make {silent} -j {cpu_count}".format(silent=silent,
-                                                                    cpu_count=tools.cpu_count())
+                        make_args.append('VERBOSE=1')
+                    args = ' '.join(make_args)
+                    command = "make {args} -j {cpu_count}".format(args=args,
+                                                                  cpu_count=tools.cpu_count())
                     self.run(command, win_bash=tools.os_info.is_windows)
                     if self.options.get_safe("with_unit_tests"):
-                        command = "make {silent} check".format(silent=silent)
+                        command = "make {args} check".format(args=args)
                         self.run(command, win_bash=tools.os_info.is_windows)
-                    command = "make {silent} install".format(silent=silent)
+                    command = "make {args} install".format(args=args)
                     self.run(command, win_bash=tools.os_info.is_windows)
 
         self._install_name_tool()


### PR DESCRIPTION
The problem with the build was that the library directories were added to the incorrect library path. The code uses `LD_LIBRARY_PATH` by default, but on our Solaris machines, we want `LD_LIBRARY_PATH_64`.

There is a Make variable `LDLIBRARYPATH_ENVVAR` that controls the variable name. Set that variable on Solaris 64-bit to use `LD_LIBRARY_PATH_64`.

In the process, generalized the way arguments are presented to the make command.
