### PR TITLE
Swap out the release candidate for ICU 67.1 for the official release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.py text eol=lf
+conandata.yml text eol=lf
+LICENSE.md text eol=lf 

--- a/conandata.yml
+++ b/conandata.yml
@@ -8,6 +8,7 @@ sources:
   "66.1":
     url: "https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz"
     sha256: "52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e"
-  "67.1":  # this is actually the release candidate
-    url: "https://github.com/unicode-org/icu/releases/download/release-67-rc/icu4c-67rc-src.tgz"
-    sha256: "a6baa7023df97515e8d6b0ec021d3a4b29ee145cb9b69f5294d3a4a82d8e0b83"
+  "67.1":
+    url: "https://github.com/unicode-org/icu/releases/download/release-67-1/icu4c-67_1-src.tgz"
+    sha256: "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc"
+


### PR DESCRIPTION
Changes in the PR consist only of the yaml file, which will be a new recipe revision.