### PR TITLE
Add some compatibility with the ICU in Conan Center Index

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -72,8 +72,10 @@ class ICUConan(ICUBase):
 
         if not self.options.shared:
             self.cpp_info.defines.append("U_STATIC_IMPLEMENTATION")
-        if self.settings.os == 'Linux':
-            self.cpp_info.libs.append('dl')
 
-        if self.settings.os == 'Windows':
-            self.cpp_info.libs.append('advapi32')
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "pthread"]
+            if self.options.with_dyload:
+                self.cpp_info.system_libs.append("dl")
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["advapi32"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class ICUConan(ICUBase):
     default_options = {"shared": False,
                        "fPIC": True,
                        "data_packaging": "archive",
-                       "with_extras": True,
+                       "with_extras": False,
                        "with_unit_tests": False,
                        "silent": True}
     generators = 'txt', 'virtualenv'

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,13 +13,15 @@ class ICUConan(ICUBase):
                "data_packaging": ["files", "archive", "library", "static"],
                "with_extras": [True, False],
                "with_unit_tests": [True, False],
-               "silent": [True, False]}
+               "silent": [True, False],
+               "with_dyload": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "data_packaging": "archive",
                        "with_extras": False,
                        "with_unit_tests": False,
-                       "silent": True}
+                       "silent": True,
+                       "with_dyload": True}
     generators = 'txt', 'virtualenv'
 
     def build_requirements(self):

--- a/icu_base.py
+++ b/icu_base.py
@@ -212,6 +212,8 @@ class ICUBase(ConanFile):
             args.append('--disable-extras')
         if not self.options.get_safe("with_unit_tests"):
             args.append('--disable-tests')
+        if not self.options.with_dyload:
+            args.append("--disable-dyload")
         return args
 
     @property


### PR DESCRIPTION
The primary goal here is to make it possible to build using Boost.Locale from CCI with a static or dynamic ICU from Datalogics. To do this, some of the options and package info have been changed to conform with what the [ICU in Conan Center Index](https://github.com/conan-io/conan-center-index/tree/master/recipes/icu/all) does.

- Make `icu:with_extras` default to `False`. This mimics the default behavior in CCI, and will allow us to remove the `icu:with_extras=False` from our profiles.
- Add `cpp_info.system_libs` in the [same way](https://github.com/conan-io/conan-center-index/blob/2cfafcd07aa03c3f29804b8226210bb290cd77c1/recipes/icu/all/conanfile.py#L269) the CCI ICU does (minus the experimental component support). The Boost recipe adds the ICU `system_libs` to the `linkflags` for `b2`, which is necessary for `b2` to detect ICU.
- Add the `with_dyload` option. This can be set to `False` when using a static ICU. When using a static ICU, Boost doesn't add the system libraries, and the lack of `-ldl` on Linux makes it think there's no ICU.

For testing, there's a `icu/68.2@kam/testing` recipe up on our Artifactory.

I've also tested this by building and testing `ocrbox` on Linux with `-o ocrbox:shared_icu=False` (the default) and `-o ocrbox:shared_icu=True`, and by adding `--build boost` to `invoke conan.install` to ensure that Boost is built and is detecting ICU.